### PR TITLE
improved indicator font customization

### DIFF
--- a/libmatekbd/matekbd-indicator-config.c
+++ b/libmatekbd/matekbd-indicator-config.c
@@ -43,7 +43,6 @@
 const gchar MATEKBD_INDICATOR_CONFIG_KEY_SHOW_FLAGS[] = "show-flags";
 const gchar MATEKBD_INDICATOR_CONFIG_KEY_SECONDARIES[] = "secondary";
 const gchar MATEKBD_INDICATOR_CONFIG_KEY_FONT_FAMILY[] = "font-family";
-const gchar MATEKBD_INDICATOR_CONFIG_KEY_FONT_SIZE[] = "font-size";
 const gchar MATEKBD_INDICATOR_CONFIG_KEY_FOREGROUND_COLOR[] = "foreground-color";
 const gchar MATEKBD_INDICATOR_CONFIG_KEY_BACKGROUND_COLOR[] = "background-color";
 
@@ -60,10 +59,6 @@ matekbd_indicator_config_load_font (MatekbdIndicatorConfig * ind_config)
 	    g_settings_get_string (ind_config->settings,
 				   MATEKBD_INDICATOR_CONFIG_KEY_FONT_FAMILY);
 
-	ind_config->font_size =
-	    g_settings_get_int (ind_config->settings,
-				  MATEKBD_INDICATOR_CONFIG_KEY_FONT_SIZE);
-
 	if (ind_config->font_family == NULL ||
 	    ind_config->font_family[0] == '\0') {
 		PangoFontDescription *fd = NULL;
@@ -76,15 +71,10 @@ matekbd_indicator_config_load_font (MatekbdIndicatorConfig * ind_config)
 			fd = style->font_desc;
 		if (fd != NULL) {
 			ind_config->font_family =
-			    g_strdup (pango_font_description_get_family
-				      (fd));
-			ind_config->font_size =
-			    pango_font_description_get_size (fd) /
-			    PANGO_SCALE;
+			    g_strdup (pango_font_description_to_string(fd));
 		}
 	}
-	xkl_debug (150, "font: [%s], size %d\n", ind_config->font_family,
-		   ind_config->font_size);
+	xkl_debug (150, "font: [%s]\n", ind_config->font_family);
 
 }
 

--- a/libmatekbd/matekbd-indicator-config.h
+++ b/libmatekbd/matekbd-indicator-config.h
@@ -32,7 +32,6 @@ typedef struct _MatekbdIndicatorConfig {
 	gboolean show_flags;
 
 	gchar *font_family;
-	int font_size;
 	gchar *foreground_color;
 	gchar *background_color;
 

--- a/libmatekbd/matekbd-status.c
+++ b/libmatekbd/matekbd-status.c
@@ -183,22 +183,6 @@ matekbd_status_render_cairo (cairo_t * cr, int group)
 		}
 	}
 
-	if (globals.ind_cfg.font_family != NULL &&
-	    globals.ind_cfg.font_family[0] != 0) {
-		cairo_select_font_face (cr, globals.ind_cfg.font_family,
-					CAIRO_FONT_SLANT_NORMAL,
-					CAIRO_FONT_WEIGHT_NORMAL);
-	}
-
-	pfd = pango_font_description_new ();
-	pango_font_description_set_family (pfd,
-					   globals.ind_cfg.font_family);
-	pango_font_description_set_style (pfd, PANGO_STYLE_NORMAL);
-	pango_font_description_set_weight (pfd, PANGO_WEIGHT_NORMAL);
-	pango_font_description_set_size (pfd,
-					 globals.ind_cfg.font_size *
-					 PANGO_SCALE);
-
 	pcc = pango_cairo_create_context (cr);
 
 	fo = cairo_font_options_copy (gdk_screen_get_font_options
@@ -229,6 +213,8 @@ matekbd_status_render_cairo (cairo_t * cr, int group)
 	pango_layout_set_text (pl, lbl_title, -1);
 
 	g_free (lbl_title);
+
+	pfd = pango_font_description_from_string (globals.ind_cfg.font_family);
 
 	pango_layout_set_font_description (pl, pfd);
 	pango_layout_get_size (pl, &lwidth, &lheight);

--- a/libmatekbd/matekbd.convert
+++ b/libmatekbd/matekbd.convert
@@ -23,6 +23,5 @@ height = /desktop/mate/peripherals/keyboard/preview/height
 secondary = /desktop/mate/peripherals/keyboard/indicator/secondary
 show-flags = /desktop/mate/peripherals/keyboard/indicator/showFlags
 font-family = /desktop/mate/peripherals/keyboard/indicator/fontFamily
-font-size = /desktop/mate/peripherals/keyboard/indicator/fontSize
 foreground-color = /desktop/mate/peripherals/keyboard/indicator/foregroundColor
 background-color = /desktop/mate/peripherals/keyboard/indicator/backgroundColor

--- a/libmatekbd/org.mate.peripherals-keyboard-xkb.gschema.xml.in.in
+++ b/libmatekbd/org.mate.peripherals-keyboard-xkb.gschema.xml.in.in
@@ -107,23 +107,18 @@
     </key>
     <key name="font-family" type="s">
       <default>''</default>
-      <_summary>The font family</_summary>
-      <_description>The font family for the layout indicator</_description>
-    </key>
-    <key name="font-size" type="i">
-      <default>10</default>
-      <_summary>The font size</_summary>
-      <_description>The font size for the layout indicator</_description>
+      <_summary>The font</_summary>
+      <_description>The font for the layout indicator. This should be in "[FAMILY-LIST] [STYLE-OPTIONS] [SIZE]" format.</_description>
     </key>
     <key name="foreground-color" type="s">
       <default>''</default>
       <_summary>The foreground color</_summary>
-      <_description>The foreground color for the layout indicator</_description>
+      <_description>The foreground color for the layout indicator. This should be in "R G B" format, for example "255 0 0".</_description>
     </key>
     <key name="background-color" type="s">
       <default>''</default>
       <_summary>The background color</_summary>
-      <_description>The background color for the layout indicator</_description>
+      <_description>The background color for the layout indicator. This should be in "R G B" format, for example "255 0 0".</_description>
     </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
This allows specifying the layout indicator font using the "[FAMILY-LIST] [STYLE-OPTIONS] [SIZE]" format (for example "sans bold 9").
Previous implementation with cairo_select_font_face() didn't allow for font styling nor for fallback font families.
This should provide better support for keyboard layout indicator look & feel customization. 

p.s. also added better descriptions of expected data formats to gconf schema.
