### PR TITLE
explicit declaration of internal libxklavier functions

### DIFF
--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -49,6 +49,14 @@ static guint matekbd_keyboard_drawing_signals[NUM_SIGNALS] = { 0 };
 static void matekbd_keyboard_drawing_set_mods (MatekbdKeyboardDrawing * drawing,
 					    guint mods);
 
+extern gboolean xkl_xkb_config_native_prepare (XklEngine * engine,
+					      const XklConfigRec * data,
+					      gpointer component_names);
+
+extern void xkl_xkb_config_native_cleanup (XklEngine * engine,
+					  gpointer component_names);
+
+
 static gint
 xkb_to_pixmap_coord (MatekbdKeyboardDrawingRenderContext * context, gint n)
 {


### PR DESCRIPTION
from lingnomekbd:
https://git.gnome.org/browse/libgnomekbd/commit/?id=18332fedc6a24e4efeecfdc78a006140c667568a
https://bugzilla.gnome.org/show_bug.cgi?id=643754
