### PR TITLE
layout view/print dialog: removed useless Help button

### DIFF
--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -2538,11 +2538,6 @@ show_layout_response (GtkWidget * dialog, gint resp)
 	const gchar *groupName;
 
 	switch (resp) {
-	case GTK_RESPONSE_HELP:
-		gtk_show_uri (gtk_widget_get_screen (GTK_WIDGET (dialog)),
-			      "ghelp:gswitchit?layout-view",
-			      gtk_get_current_event_time (), NULL);
-		return;
 	case GTK_RESPONSE_CLOSE:
 		gtk_window_get_position (GTK_WINDOW (dialog), &rect.x,
 					 &rect.y);

--- a/libmatekbd/show-layout.ui
+++ b/libmatekbd/show-layout.ui
@@ -42,18 +42,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="btnHelp">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="label">gtk-help</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkButton" id="btnClose">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>


### PR DESCRIPTION
the link that it led to was never valid anyway - no such page in user guide

adapted from
https://git.gnome.org/browse/libgnomekbd/commit?id=2eff72e73386c3812841007d8cda14880a7cf387