### PR TITLE
configure.ac: drop obsolete macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,6 @@ dnl ***************************************************************************
 MATE_COMMON_INIT
 MATE_COMPILE_WARNINGS
 
-AC_ISC_POSIX
 AC_PROG_CC
 AC_STDC_HEADERS
 AM_PROG_LIBTOOL


### PR DESCRIPTION
It's been a no-op for a long time.
See https://mail.gnome.org/archives/commits-list/2011-December/msg00681.html for example.