### PR TITLE
keyboard layout view improvements

### DIFF
--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -2094,8 +2094,6 @@ matekbd_keyboard_drawing_init (MatekbdKeyboardDrawing * drawing)
 	drawing->track_modifiers = 0;
 	drawing->track_config = 0;
 
-	gtk_widget_set_double_buffered (GTK_WIDGET (drawing), FALSE);
-
 	/* XXX: XkbClientMapMask | XkbIndicatorMapMask | XkbNamesMask | XkbGeometryMask */
 	drawing->xkb = XkbGetKeyboard (drawing->display,
 				       XkbGBN_GeometryMask |

--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -2176,6 +2176,11 @@ matekbd_keyboard_drawing_new (void)
 static void
 matekbd_keyboard_drawing_class_init (MatekbdKeyboardDrawingClass * klass)
 {
+#if GTK_CHECK_VERSION (3, 20, 0)
+	GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+	gtk_widget_class_set_css_name (widget_class, "matekbd-keyboard-drawing");
+#endif
+
 	klass->bad_keycode = NULL;
 
 	matekbd_keyboard_drawing_signals[BAD_KEYCODE] =

--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -1913,6 +1913,9 @@ free_cdik (			/*colors doodads indicators keys */
 static void
 alloc_cdik (MatekbdKeyboardDrawing * drawing)
 {
+	if (!drawing->xkb)
+		return;
+
 	drawing->physical_indicators_size =
 	    drawing->xkb->indicators->phys_indicators + 1;
 	drawing->physical_indicators =
@@ -2101,24 +2104,20 @@ matekbd_keyboard_drawing_init (MatekbdKeyboardDrawing * drawing)
 				       XkbGBN_SymbolsMask |
 				       XkbGBN_IndicatorMapMask,
 				       XkbUseCoreKbd);
-	if (drawing->xkb == NULL) {
-		g_critical
-		    ("XkbGetKeyboard failed to get keyboard from the server!");
-		return;
+	if (drawing->xkb) {
+		XkbGetNames (drawing->display, XkbAllNamesMask, drawing->xkb);
+		XkbSelectEventDetails (drawing->display, XkbUseCoreKbd,
+				       XkbIndicatorStateNotify,
+				       drawing->xkb->indicators->phys_indicators,
+				       drawing->xkb->indicators->phys_indicators);
 	}
 
-	XkbGetNames (drawing->display, XkbAllNamesMask, drawing->xkb);
 	drawing->l3mod = XkbKeysymToModifiers (drawing->display,
 					       GDK_KEY_ISO_Level3_Shift);
 
 	drawing->xkbOnDisplay = TRUE;
 
 	alloc_cdik (drawing);
-
-	XkbSelectEventDetails (drawing->display, XkbUseCoreKbd,
-			       XkbIndicatorStateNotify,
-			       drawing->xkb->indicators->phys_indicators,
-			       drawing->xkb->indicators->phys_indicators);
 
 	mask =
 	    (XkbStateNotifyMask | XkbNamesNotifyMask |
@@ -2325,8 +2324,12 @@ matekbd_keyboard_drawing_set_keyboard (MatekbdKeyboardDrawing * drawing,
 		drawing->xkbOnDisplay = TRUE;
 	}
 
-	if (drawing->xkb == NULL)
-		return FALSE;
+	if (drawing->xkb) {
+		XkbSelectEventDetails (drawing->display, XkbUseCoreKbd,
+				       XkbIndicatorStateNotify,
+				       drawing->xkb->indicators->phys_indicators,
+				       drawing->xkb->indicators->phys_indicators);
+	}
 
 	alloc_cdik (drawing);
 

--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -39,6 +39,8 @@
 
 #define GTK_RESPONSE_PRINT 2
 
+#define KEY_FONT_SIZE 12
+
 enum {
 	BAD_KEYCODE = 0,
 	NUM_SIGNALS
@@ -1519,7 +1521,7 @@ context_setup_scaling (MatekbdKeyboardDrawingRenderContext * context,
 	}
 
 	pango_font_description_set_size (context->font_desc,
-					 720 * dpi_x *
+					 72 * KEY_FONT_SIZE * dpi_x *
 					 context->scale_numerator /
 					 context->scale_denominator);
 	pango_layout_set_spacing (context->layout,

--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -1585,7 +1585,7 @@ key_event (GtkWidget * widget,
 	}
 
 	invalidate_key_region (drawing, key);
-	return FALSE;
+	return TRUE;
 }
 
 static gint


### PR DESCRIPTION
After all  the keyboard layout view can be look like this with this theme setting.
```
/* mate-keyboard-layout-view, mate-keyboard-layout-chooser */
/* this way it styles only the border of the keys, the bg of the map itself
   use the .view class from code */
matekbd-keyboard-drawing {
    background-color: shade (@theme_bg_color, 1.0);
}

matekbd-keyboard-drawing:selected {
        background-color: @theme_selected_bg_color;
        color: @theme_selected_fg_color;
}
```
![keyboard-map](https://cloud.githubusercontent.com/assets/961604/24587645/ab79719a-17ba-11e7-86d6-034f90c14333.png)
Adding the css name is needed to avoid using stupid wildcards in themes to set the selected colors for keys.
ie. *:selected {}
Because you never know what you style with a wildcard.
