### PR TITLE
deprecation fixes and a back port

### DIFF
--- a/libmatekbd/matekbd-indicator-config.c
+++ b/libmatekbd/matekbd-indicator-config.c
@@ -139,7 +139,7 @@ matekbd_indicator_config_refresh_style (MatekbdIndicatorConfig * ind_config)
 	matekbd_indicator_config_load_colors (ind_config);
 }
 
-char *
+gchar *
 matekbd_indicator_config_get_images_file (MatekbdIndicatorConfig *
 				       ind_config,
 				       MatekbdKeyboardConfig *
@@ -164,6 +164,13 @@ matekbd_indicator_config_get_images_file (MatekbdIndicatorConfig *
 				/* probably there is something in theme? */
 				icon_info = gtk_icon_theme_lookup_icon
 				    (ind_config->icon_theme, l, 48, 0);
+
+				/* Unbelievable but happens */
+				if (icon_info != NULL &&
+				    gtk_icon_info_get_filename (icon_info) == NULL) {
+					g_object_unref (icon_info);
+					icon_info = NULL;
+				}
 			}
 		}
 	}
@@ -195,7 +202,7 @@ matekbd_indicator_config_load_image_filenames (MatekbdIndicatorConfig *
 
 	for (i = xkl_engine_get_max_num_groups (ind_config->engine);
 	     --i >= 0;) {
-		char *image_file =
+		gchar *image_file =
 		    matekbd_indicator_config_get_images_file (ind_config,
 							   kbd_config,
 							   i);

--- a/libmatekbd/matekbd-indicator.c
+++ b/libmatekbd/matekbd-indicator.c
@@ -251,35 +251,28 @@ matekbd_indicator_button_pressed (GtkWidget *
 }
 
 static void
-flag_exposed (GtkWidget * flag, GdkEventExpose * event, GdkPixbuf * image)
+draw_flag (GtkWidget * flag, cairo_t * cr, GdkPixbuf * image)
 {
 	/* Image width and height */
 	int iw = gdk_pixbuf_get_width (image);
 	int ih = gdk_pixbuf_get_height (image);
 	GtkAllocation allocation;
 	double xwiratio, ywiratio, wiratio;
-        cairo_t *cr;
 
 	gtk_widget_get_allocation (flag, &allocation);
-
-        cr = gdk_cairo_create (event->window);
-        gdk_cairo_region (cr, event->region);
-        cairo_clip (cr);
 
 	/* widget-to-image scales, X and Y */
 	xwiratio = 1.0 * allocation.width / iw;
 	ywiratio = 1.0 * allocation.height / ih;
 	wiratio = xwiratio < ywiratio ? xwiratio : ywiratio;
 
-        /* transform cairo context */
-        cairo_translate (cr, allocation.width / 2.0, allocation.height / 2.0);
-        cairo_scale (cr, wiratio, wiratio);
-        cairo_translate (cr, - iw / 2.0, - ih / 2.0);
+	/* transform cairo context */
+	cairo_translate (cr, allocation.width / 2.0, allocation.height / 2.0);
+	cairo_scale (cr, wiratio, wiratio);
+	cairo_translate (cr, - iw / 2.0, - ih / 2.0);
 
-        gdk_cairo_set_source_pixbuf (cr, image, 0, 0);
-        cairo_paint (cr);
-
-        cairo_destroy (cr);
+	gdk_cairo_set_source_pixbuf (cr, image, 0, 0);
+	cairo_paint (cr);
 }
 
 gchar *
@@ -382,8 +375,8 @@ matekbd_indicator_prepare_drawing (MatekbdIndicator * gki, int group)
 		flag = gtk_drawing_area_new ();
 		gtk_widget_add_events (GTK_WIDGET (flag),
 				       GDK_BUTTON_PRESS_MASK);
-		g_signal_connect (G_OBJECT (flag), "expose_event",
-				  G_CALLBACK (flag_exposed), image);
+		g_signal_connect (G_OBJECT (flag), "draw",
+		                  G_CALLBACK (draw_flag), image);
 		gtk_container_add (GTK_CONTAINER (ebox), flag);
 	} else {
 		char *lbl_title = NULL;

--- a/libmatekbd/matekbd-indicator.c
+++ b/libmatekbd/matekbd-indicator.c
@@ -388,7 +388,7 @@ matekbd_indicator_prepare_drawing (MatekbdIndicator * gki, int group)
 	} else {
 		char *lbl_title = NULL;
 		char *layout_name = NULL;
-		GtkWidget *align, *label;
+		GtkWidget *label;
 		static GHashTable *ln2cnt_map = NULL;
 
 		layout_name =
@@ -403,8 +403,15 @@ matekbd_indicator_prepare_drawing (MatekbdIndicator * gki, int group)
 						       &ln2cnt_map,
 						       layout_name);
 
-		align = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
 		label = gtk_label_new (lbl_title);
+		gtk_widget_set_halign (label, GTK_ALIGN_CENTER);
+		gtk_widget_set_valign (label, GTK_ALIGN_CENTER);
+		gtk_widget_set_hexpand (label, TRUE);
+		gtk_widget_set_vexpand (label, TRUE);
+		gtk_widget_set_margin_start (label, 2);
+		gtk_widget_set_margin_end (label, 2);
+		gtk_widget_set_margin_top (label, 2);
+		gtk_widget_set_margin_bottom (label, 2);
 		g_free (lbl_title);
 		gtk_label_set_angle (GTK_LABEL (label), gki->priv->angle);
 
@@ -414,10 +421,7 @@ matekbd_indicator_prepare_drawing (MatekbdIndicator * gki, int group)
 			ln2cnt_map = NULL;
 		}
 
-		gtk_container_add (GTK_CONTAINER (align), label);
-		gtk_container_add (GTK_CONTAINER (ebox), align);
-
-		gtk_container_set_border_width (GTK_CONTAINER (align), 2);
+		gtk_container_add (GTK_CONTAINER (ebox), label);
 	}
 
 	g_signal_connect (G_OBJECT (ebox),


### PR DESCRIPTION
matekbd-indicator: don't use deprecated GtkAlignment
is if the applet use text for indicate the locale.
matekbd-indicator: don't use deprecated gdk_cairo_create
is when flags are displayed.
This can be easily tested with new mate-icon-theme-1.18.1 or 1.16.1 and you need to enable
```
[rave@mother ~]$ gsettings get org.mate.peripherals-keyboard-xkb.indicator show-flags
true
```
