### PR TITLE
matekbd-status: Fix Gdk-CRITICAL warning on creating status bar icon

### DIFF
--- a/libmatekbd/matekbd-status.c
+++ b/libmatekbd/matekbd-status.c
@@ -635,7 +635,8 @@ matekbd_status_init (MatekbdStatus * gki)
 	gki->priv = g_new0 (MatekbdStatusPrivate, 1);
 
 	/* This should give NA a hint about the order */
-	gtk_status_icon_set_name (GTK_STATUS_ICON (gki), "keyboard");
+	/* commenting out fixes a Gdk-critical warning */
+/*	gtk_status_icon_set_name (GTK_STATUS_ICON (gki), "keyboard"); */
 
 	xkl_debug (100, "Initiating the widget startup process for %p\n",
 		   gki);


### PR DESCRIPTION
```
Gdk-CRITICAL **: gdk_window_thaw_toplevel_updates: assertion
'window->update_and_descendants_freeze_count > 0' failed
```

inspired from:
https://git.xfce.org/apps/xfce4-terminal/commit/?id=eff5e2d