### PR TITLE
rename g_strv_equal to matekbd_strv_equal

### DIFF
--- a/libmatekbd/matekbd-keyboard-config.c
+++ b/libmatekbd/matekbd-keyboard-config.c
@@ -53,7 +53,7 @@ const gchar *MATEKBD_KEYBOARD_CONFIG_ACTIVE[] = {
  */
 
 static gboolean
-g_strv_equal (gchar ** l1, gchar ** l2)
+matekbd_strv_equal (gchar ** l1, gchar ** l2)
 {
 	if (l1 == l2)
 		return TRUE;
@@ -555,7 +555,7 @@ matekbd_keyboard_config_equals (MatekbdKeyboardConfig * kbd_config1,
 	    (kbd_config2->model != NULL) &&
 	    g_ascii_strcasecmp (kbd_config1->model, kbd_config2->model))
 		return False;
-	if (!g_strv_equal (kbd_config1->layouts_variants,
+	if (!matekbd_strv_equal (kbd_config1->layouts_variants,
 			   kbd_config2->layouts_variants))
 		return False;
 


### PR DESCRIPTION
it conflicts with the newly added g_strv_equal in glib

Based on https://github.com/GNOME/libgnomekbd/commit/7e0b6f0a96477c5d12434231ea413d3a16658ed0