### PR TITLE
matekbd-keyboard-drawing: Uninitialized structure member

### DIFF
--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -2206,6 +2206,7 @@ matekbd_keyboard_drawing_get_type (void)
 			sizeof (MatekbdKeyboardDrawing),
 			0,	/* n_preallocs */
 			(GInstanceInitFunc) matekbd_keyboard_drawing_init,
+			NULL	/* *value_table */
 		};
 
 		matekbd_keyboard_drawing_type =


### PR DESCRIPTION
Initializer block for matekbd_keyboard_drawing_info has 9 fields, but GTypeInfo has 10 fields.