### PR TITLE
build: add configuration summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,3 +123,25 @@ libmatekbd/Makefile
 libmatekbd/org.mate.peripherals-keyboard-xkb.gschema.xml
 test/Makefile
 ])
+
+AC_OUTPUT
+
+dnl ---------------------------------------------------------------------------
+dnl - Show summary
+dnl ---------------------------------------------------------------------------
+
+echo "
+Configuration:
+
+    prefix:                       ${prefix}
+    exec_prefix:                  ${exec_prefix}
+    libdir:                       ${libdir}
+    bindir:                       ${bindir}
+    sbindir:                      ${sbindir}
+    sysconfdir:                   ${sysconfdir}
+    datadir:                      ${datadir}
+    source code location:         ${srcdir}
+    compiler:                     ${CC}
+    cflags:                       ${CFLAGS}
+    Warning flags:                ${WARN_CFLAGS}
+"


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum
<cut>

Configuration:

    prefix:                       /usr/local
    exec_prefix:                  ${prefix}
    libdir:                       ${exec_prefix}/lib
    bindir:                       ${exec_prefix}/bin
    sbindir:                      ${exec_prefix}/sbin
    sysconfdir:                   ${prefix}/etc
    datadir:                      ${datarootdir}
    source code location:         .
    compiler:                     gcc
    cflags:                       -g -O2
    Warning flags:                -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare

Now type `make' to compile libmatekbd
<cut>
```