### PR TITLE
build: show package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,10 @@ dnl - Show summary
 dnl ---------------------------------------------------------------------------
 
 echo "
-Configuration:
+Configure summary:
+
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
     prefix:                       ${prefix}
     exec_prefix:                  ${exec_prefix}


### PR DESCRIPTION
Test:
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

    libmatekbd 1.25.0
    =================

    prefix:                       /usr
    exec_prefix:                  ${prefix}
    libdir:                       ${exec_prefix}/lib64
    bindir:                       ${exec_prefix}/bin
    sbindir:                      ${exec_prefix}/sbin
    sysconfdir:                   /etc
    datadir:                      ${datarootdir}
    source code location:         .
    compiler:                     gcc
    cflags:                       -g -O2
    Warning flags:                -Wall -Wmissing-prototypes

Now type `make' to compile libmatekbd
```