### PR TITLE
matekbd-keyboard-drawing-test: -Wmissing-field-initializers

### DIFF
--- a/test/matekbd-keyboard-drawing-test.c
+++ b/test/matekbd-keyboard-drawing-test.c
@@ -67,7 +67,7 @@ static const GOptionEntry options[] = {
 	 "Track the server XKB configuration", NULL},
 	{"version", '\0', 0, G_OPTION_ARG_NONE, &program_version,
 	 "Show current version", NULL},
-	{NULL},
+	{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL},
 };
 
 static gboolean


### PR DESCRIPTION
```
matekbd-keyboard-drawing-test.c:70:7: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        {NULL},
             ^
```