### PR TITLE
matekbd-keyboard-drawing: fix memory leak

### DIFF
--- a/libmatekbd/matekbd-keyboard-drawing.c
+++ b/libmatekbd/matekbd-keyboard-drawing.c
@@ -2097,6 +2097,7 @@ free_cdik (			/*colors doodads indicators keys */
 	g_list_free (drawing->keyboard_items);
 	drawing->keyboard_items = NULL;
 
+	g_free (drawing->physical_indicators);
 	g_free (drawing->keys);
 	g_free (drawing->colors);
 }
@@ -2239,6 +2240,8 @@ destroy (MatekbdKeyboardDrawing * drawing)
 	if (drawing->surface != NULL) {
 		cairo_surface_destroy (drawing->surface);
 	}
+
+	free_cdik (drawing);
 }
 
 static void


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks

Direct leak of 16384 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d58b7aaf7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7f2d57406584 in g_malloc0 ../glib/gmem.c:136
    #2 0x7f2d574068d2 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7f2d5851c0a5 in alloc_cdik /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2113
    #4 0x7f2d5851e813 in matekbd_keyboard_drawing_set_keyboard /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2529
    #5 0x7f2d5852030f in matekbd_keyboard_drawing_new_dialog /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2860
    #6 0x40c55d in show_selected_layout /home/robert/builddir.gcc/mate-control-center/capplets/keyboard/mate-keyboard-properties-xkblt.c:360
    #7 0x7f2d57516247 in g_cclosure_marshal_VOID__VOIDv ../gobject/gmarshal.c:165
    #8 0x7f2d575128a1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #9 0x7f2d57533cd2 in g_signal_emit_valist ../gobject/gsignal.c:3406
    #10 0x7f2d5753520e in g_signal_emit ../gobject/gsignal.c:3553
    #11 0x7f2d57e0c63f in gtk_real_button_released (/lib64/libgtk-3.so.0+0x13e63f)

Direct leak of 16384 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d58b7aaf7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7f2d57406584 in g_malloc0 ../glib/gmem.c:136
    #2 0x7f2d574068d2 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7f2d5851c0a5 in alloc_cdik /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2113
    #4 0x7f2d5851d6fe in matekbd_keyboard_drawing_init /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2308
    #5 0x7f2d57537983 in g_type_create_instance ../gobject/gtype.c:1929
    #6 0x7f2d5751cd64 in g_object_new_internal ../gobject/gobject.c:1970
    #7 0x7f2d5751c300 in g_object_new_with_properties ../gobject/gobject.c:2139
    #8 0x7f2d5751c083 in g_object_new ../gobject/gobject.c:1810
    #9 0x7f2d5851dbab in matekbd_keyboard_drawing_new /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2360
    #10 0x7f2d5851fcd2 in matekbd_keyboard_drawing_new_dialog /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2815
    #11 0x40c55d in show_selected_layout /home/robert/builddir.gcc/mate-control-center/capplets/keyboard/mate-keyboard-properties-xkblt.c:360
    #12 0x7f2d57516247 in g_cclosure_marshal_VOID__VOIDv ../gobject/gmarshal.c:165
    #13 0x7f2d575128a1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #14 0x7f2d57533cd2 in g_signal_emit_valist ../gobject/gsignal.c:3406
    #15 0x7f2d5753520e in g_signal_emit ../gobject/gsignal.c:3553
    #16 0x7f2d57e0c63f in gtk_real_button_released (/lib64/libgtk-3.so.0+0x13e63f)

Direct leak of 192 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d58b7a93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f2d574064ff in g_malloc ../glib/gmem.c:106
    #2 0x7f2d57406842 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f2d5851bad8 in init_colors /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2058
    #4 0x7f2d5851e82b in matekbd_keyboard_drawing_set_keyboard /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2532
    #5 0x7f2d5852030f in matekbd_keyboard_drawing_new_dialog /home/robert/builddir.gcc/libmatekbd/libmatekbd/matekbd-keyboard-drawing.c:2860
    #6 0x40c55d in show_selected_layout /home/robert/builddir.gcc/mate-control-center/capplets/keyboard/mate-keyboard-properties-xkblt.c:360
    #7 0x7f2d57516247 in g_cclosure_marshal_VOID__VOIDv ../gobject/gmarshal.c:165
    #8 0x7f2d575128a1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #9 0x7f2d57533cd2 in g_signal_emit_valist ../gobject/gsignal.c:3406
    #10 0x7f2d5753520e in g_signal_emit ../gobject/gsignal.c:3553
    #11 0x7f2d57e0c63f in gtk_real_button_released (/lib64/libgtk-3.so.0+0x13e63f)
```