### PR TITLE
Use correct version information for dynamic libraries

### DIFF
--- a/libmatekbd/Makefile.am
+++ b/libmatekbd/Makefile.am
@@ -14,7 +14,7 @@ common_CFLAGS =					\
 	-DLIBDIR=\"$(libdir)\"			\
 	$(NULL)
 
-common_LDFLAGS = -version-info @VERSION_INFO@ -no-undefined
+common_LDFLAGS = -version-number @VERSION_INFO@ -no-undefined
 
 common_LIBADD =					\
 	$(GDK_LIBS)				\


### PR DESCRIPTION
The version number of the library function should use the one provided in the ```configure.ac``` file
```VERSION_INFO=6:0:2 ```

fix before
```
# The name that we can dlopen(3).
dlname='libmatekbd.so.4'

# Names of this library.
library_names='libmatekbd.so.4.0.2 libmatekbd.so.4 libmatekbd.so'

# The name of the static archive.
old_library=''

# Linker flags that cannot go in dependency_libs.
inherited_linker_flags=' -pthread'

```

fix after 
```
# The name that we can dlopen(3).
dlname='libmatekbd.so.6'

# Names of this library.
library_names='libmatekbd.so.6.0.2 libmatekbd.so.6 libmatekbd.so'

# The name of the static archive.
old_library=''

# Linker flags that cannot go in dependency_libs.
inherited_linker_flags=' -pthread'

```