### PR TITLE
meson: Compile gsettings schemas

### DIFF
--- a/meson-postinstall.sh
+++ b/meson-postinstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -z "$DESTDIR" ]; then
+  echo Compiling GSettings schemas...
+  glib-compile-schemas ${MESON_INSTALL_PREFIX}/share/glib-2.0/schemas
+fi

--- a/meson.build
+++ b/meson.build
@@ -57,3 +57,5 @@ subdir('po')
 if get_option('tests')
   subdir('test')
 endif
+
+meson.add_install_script('meson-postinstall.sh')


### PR DESCRIPTION
Same as https://github.com/mate-desktop/mate-wayland-session/commit/9bc03ecd9cfdb7ba16a76fa6a569982222d3d422.

Since we install the `org.mate.peripherals-keyboard-xkb` gschemas here, it makes sense for us to do that. This is also done in autotools build via `@GSETTINGS_RULES@`.